### PR TITLE
modified for DSM 7.2, 7.1.1, and default to local logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If you're using *compose* for your containers, I highly recommend that before yo
 $ cd /volume1/docker/{my_container}
 $ docker-compose down
 ```
-Because this upgrade modifies the default logger for docker, stopping (removing) and re-starting each container is required, since the logging mechanism is persisted during a compose docker build / start. You don't HAVE to do this before the upgrade, however if you don't, you'll get errors related to the logger for your containers, and will anyway have to stop and start each container / stack after the upgrade anyway.
+Because this upgrade modifies the default logger for docker, stopping (removing) and re-starting each container is required, since the logging mechanism is persisted during a compose docker build / start. You don't HAVE to do this before the upgrade, however if you don't, you'll get errors related to the logger for your containers, and will have to stop and start each container / stack after the upgrade anyway.
 
 Stopping all the containers prior to the upgrade / restore will also make the upgrade a lot faster, since the service stop and restart normally has to do the work of stopping and starting all containers.
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ $ cd synology-docker
 $ sudo ./syno_docker_update.sh [OPTIONS] COMMAND
 ```
 
+## Preparation before upgrade
+If you're using *compose* for your containers, I highly recommend that before you run the upgrade (or restore, if you're going back to the original version) you go through and stop each running container.
+```console
+$ cd /volume1/docker/{my_container}
+$ docker-compose down
+```
+Because this upgrade modifies the default logger for docker, stopping (removing) and re-starting each container is required, since the logging mechanism is persisted during a compose docker build / start. You don't HAVE to do this before the upgrade, however if you don't, you'll get errors related to the logger for your containers, and will anyway have to stop and start each container / stack after the upgrade anyway.
+
+Stopping all the containers prior to the upgrade / restore will also make the upgrade a lot faster, since the service stop and restart normally has to do the work of stopping and starting all containers.
+
+For a convenient way of enumerating all of the running *compose* projects (you might see some duplicates if you're using compose projects with multiple containers), you can execute the following:
+
+```console
+for c in `docker ps -q`; do docker inspect $c --format '{{index .Config.Labels "com.docker.compose.project.config_files"}}' ; done
+```
+
 ### Commands
 *Synology-Docker* supports the following commands. 
 

--- a/README.md
+++ b/README.md
@@ -79,17 +79,9 @@ Because this upgrade modifies the default logger for docker, stopping (removing)
 
 Stopping all the containers prior to the upgrade / restore will also make the upgrade a lot faster, since the service stop and restart normally has to do the work of stopping and starting all containers.
 
-For a convenient way of enumerating all of the running *compose* projects, you can execute the following:
+For a convenient way of enumerating all of the running *compose* projects, run the script `syno_docker_list_containers.sh`:
 
-```console
-for c in $(docker ps -q); do \
-    docker inspect "$c" --format \
-    '{{.Name}} {{if index .Config.Labels "com.docker.compose.project.config_files"}}{{index .Config.Labels "com.docker.compose.project.config_files"}}{{else}}!---not_managed_by_compose---!{{end}}'; \
-done \
-| sort -u -t " " -k 2 \
-| column -t -N Container,Compose_Location
-```
-...if you see a container with `!---not_managed_by_compose---!` you'll need to make sure you know how to recreate this container after the upgrade.
+...if you see a container listed with `!---not_managed_by_compose---!` you'll need to make sure you know how to recreate this container after the upgrade.
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ Under the hood, the five different commands invoke a specific workflow or sequen
 * **F) Extract downloaded binaries** - Extracts the files from a downloaded archive to the temp directory (`/tmp/docker_update`). 
 * **G) Restore Docker binaries** - Restores the Docker binaries in `/var/packages/Docker/target/usr/bin/*` with the binaries extracted from a backup archive.
 * **H) Install Docker binaries** - Installs downloaded and extracted Docker binaries (including Docker Compose) to the folder `/var/packages/Docker/target/usr/bin/`.
-* **I) Update log driver** - Replaces Synology's log driver with a default log driver `json-file` to improve compatibility. The configuration is updated at `/var/packages/Docker/etc/dockerd.json`
+* **I) Update log driver** - Replaces Synology's log driver with a default log driver `local` to improve compatibility while optimizing writes and limiting log file growth. The configuration is updated at `/var/packages/Docker/etc/dockerd.json`
 * **J) Restore log driver** - Restores the log driver (`/var/packages/Docker/etc/dockerd.json`) from the configuration within a backup archive.
 * **K) Update Docker script** - Updates Synology's `start-stop-status` script for Docker to enable IP forwarding. This ensures containers can be properly reached in bridge networking mode. The script is updated at the location `/var/packages/Docker/scripts/start-stop-status`.
 * **L) Restore Docker script** - Restores the `start-stop-status` script (`/var/packages/Docker/scripts/start-stop-status`) from the file within a backup archive.
-* **M) Start Docker daemon** - Starts the Docker daemon by invoking `synoservicectl --start pkgctl-Docker`.
+* **M) Start Docker daemon** - Starts the Docker daemon by invoking `synoservicectl --start pkgctl-Docker` (or `synopkg start ContainerManager` on DSM 7).
 * **N) Clean temp folder** - Removes files from the temp directory (`/tmp/docker_update`). The temporary files are created when extracting a downloaded archive or extracting a backup.
 
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ The project uses [Docker][docker_url], a lightweight virtualization application.
 Deployment of *Synology-Docker* is a matter of cloning the GitHub repository. Login to your NAS terminal via SSH first. Assuming you are in the working folder of your choice, clone the repository files. Git automatically creates a new folder `synology-docker` and copies the files to this directory. Then change your current folder to simplify the execution of the shell script.
 
 ```console
-$ git clone https://github.com/markdumay/synology-docker.git
-$ cd synology-docker
+git clone https://github.com/telnetdoogie/synology-docker.git
+cd synology-docker
 ```
 
 <!-- TODO: TEST CHMOD -->
@@ -72,24 +72,29 @@ $ cd synology-docker
 ## Preparation before upgrade
 If you're using *compose* for your containers, I highly recommend that before you run the upgrade (or restore, if you're going back to the original version) you go through and stop each running container.
 ```console
-$ cd /volume1/docker/{my_container}
-$ docker-compose down
+cd /volume1/docker/{my_container}
+docker-compose down
 ```
 Because this upgrade modifies the default logger for docker, stopping (removing) and re-starting each container is required, since the logging mechanism is persisted during a compose docker build / start. You don't HAVE to do this before the upgrade, however if you don't, you'll get errors related to the logger for your containers, and will have to stop and start each container / stack after the upgrade anyway.
 
 Stopping all the containers prior to the upgrade / restore will also make the upgrade a lot faster, since the service stop and restart normally has to do the work of stopping and starting all containers.
 
-For a convenient way of enumerating all of the running *compose* projects, run the script `syno_docker_list_containers.sh`
+For a convenient way of enumerating all of the running compose projects, run the script:
 
-...if you see a container listed with `!---not_managed_by_compose---!` you'll need to make sure you know how to recreate this container after the upgrade.
+```console
+./syno_docker_list_containers.sh
+```
 
+...if you see a container listed with !---not_managed_by_compose---! you'll need to make sure you know how to recreate this container after the upgrade.
 
 ## Usage
 *Synology-Docker* requires `sudo` rights. Use the following command to invoke *Synology-Docker* from the command line.
 
 ```console
-$ sudo ./syno_docker_update.sh [OPTIONS] COMMAND
+sudo ./syno_docker_update.sh [OPTIONS] COMMAND
 ```
+
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Detailed background information is available on the author's [personal blog][blo
 The project uses [Docker][docker_url], a lightweight virtualization application.
 
 ## Prerequisites
-*Synology-Docker* runs on a Synology NAS with DSM 6 or DSM 7. The script has been tested with a DS918+ running DSM 6.2.4-25556 and DSM 7.0.1-42218. Other prerequisites are:
+*Synology-Docker* runs on a Synology NAS with DSM 6 or DSM 7. The script has been tested with a DS918+ running DSM 6.2.4-25556, DSM 7.0.1-42218, and DSM 7.2.1-69057. Other prerequisites are:
 
 * **SSH admin access is required** - *Synology-Docker* runs as a shell script on the terminal. You can enable SSH access in DSM under `Control Panel ➡ Terminal & SNMP ➡ Terminal`.
 

--- a/README.md
+++ b/README.md
@@ -68,14 +68,6 @@ $ cd synology-docker
 ```
 
 <!-- TODO: TEST CHMOD -->
-
-## Usage
-*Synology-Docker* requires `sudo` rights. Use the following command to invoke *Synology-Docker* from the command line.
-
-```console
-$ sudo ./syno_docker_update.sh [OPTIONS] COMMAND
-```
-
 ## Preparation before upgrade
 If you're using *compose* for your containers, I highly recommend that before you run the upgrade (or restore, if you're going back to the original version) you go through and stop each running container.
 ```console
@@ -93,6 +85,15 @@ for c in `docker ps -q`; do \
     docker inspect $c --format '{{index .Config.Labels "com.docker.compose.project.config_files"}}' ; done \
     | sort -u
 ```
+
+## Usage
+*Synology-Docker* requires `sudo` rights. Use the following command to invoke *Synology-Docker* from the command line.
+
+```console
+$ sudo ./syno_docker_update.sh [OPTIONS] COMMAND
+```
+
+
 
 ### Commands
 *Synology-Docker* supports the following commands. 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@
 | :warning: The repository 'Synology-Docker' is not supported by Synology and can potentially lead to malfunctioning of your NAS. Use this script at your own risk. Please keep a backup of your files. |
 | --- |
 
+| :warning: If you're using the Nvidia driver on your synology, you will need to re-start the Nvidia driver, or re-run `nvidia-ctk runtime configure` to re-add the nvidia runtime after each run of this script in order for the driver to get re-added to docker. |
+| --- |
+
+| :exclamation: Portainer Users - Portainer currently has an [issue](https://github.com/portainer/portainer/issues/10462) where it persists the first-used logging driver alongside container definitions. You may have to completely recreate (or duplicate and edit) containers created in portainer to use the `local` log driver. It would be best to do that with all of your containers BEFORE running this update. Portainer has created some challenges for users migrating from one log driver to another. You may need to spend more time re-creating containers after this update than if you were using compose.
+| --- |
+
 [Synology][synology_url] is a popular manufacturer of Network Attached Storage (NAS) devices. It provides a web-based user interface called Disk Station Manager (DSM). Synology also supports Docker on selected [models][synology_docker]. Docker is a lightweight virtualization application that gives you the ability to run containers directly on your NAS. The add-on package provided by Synology to install Docker is typically a version behind on the latest available version from Docker. *Synology-Docker* is a POSIX-compliant shell script to update both the Docker Engine and Docker Compose on your NAS to the latest version or a specified version.
 
 <!-- TODO: add tutorial deep-link 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ $ cd synology-docker
 ```
 
 <!-- TODO: TEST CHMOD -->
+
 ## Preparation before upgrade
 If you're using *compose* for your containers, I highly recommend that before you run the upgrade (or restore, if you're going back to the original version) you go through and stop each running container.
 ```console
@@ -81,10 +82,15 @@ Stopping all the containers prior to the upgrade / restore will also make the up
 For a convenient way of enumerating all of the running *compose* projects, you can execute the following:
 
 ```console
-for c in `docker ps -q`; do \
-    docker inspect $c --format '{{index .Config.Labels "com.docker.compose.project.config_files"}}' ; done \
-    | sort -u
+for c in $(docker ps -q); do \
+    docker inspect "$c" --format \
+    '{{.Name}} {{if index .Config.Labels "com.docker.compose.project.config_files"}}{{index .Config.Labels "com.docker.compose.project.config_files"}}{{else}}!---not_managed_by_compose---!{{end}}'; \
+done \
+| sort -u -t " " -k 2 \
+| column -t -N Container,Compose_Location
 ```
+...if you see a container with `!---not_managed_by_compose---!` you'll need to make sure you know how to recreate this container after the upgrade.
+
 
 ## Usage
 *Synology-Docker* requires `sudo` rights. Use the following command to invoke *Synology-Docker* from the command line.

--- a/README.md
+++ b/README.md
@@ -86,10 +86,12 @@ Because this upgrade modifies the default logger for docker, stopping (removing)
 
 Stopping all the containers prior to the upgrade / restore will also make the upgrade a lot faster, since the service stop and restart normally has to do the work of stopping and starting all containers.
 
-For a convenient way of enumerating all of the running *compose* projects (you might see some duplicates if you're using compose projects with multiple containers), you can execute the following:
+For a convenient way of enumerating all of the running *compose* projects, you can execute the following:
 
 ```console
-for c in `docker ps -q`; do docker inspect $c --format '{{index .Config.Labels "com.docker.compose.project.config_files"}}' ; done
+for c in `docker ps -q`; do \
+    docker inspect $c --format '{{index .Config.Labels "com.docker.compose.project.config_files"}}' ; done \
+    | sort -u
 ```
 
 ### Commands

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Because this upgrade modifies the default logger for docker, stopping (removing)
 
 Stopping all the containers prior to the upgrade / restore will also make the upgrade a lot faster, since the service stop and restart normally has to do the work of stopping and starting all containers.
 
-For a convenient way of enumerating all of the running *compose* projects, run the script `syno_docker_list_containers.sh`:
+For a convenient way of enumerating all of the running *compose* projects, run the script `syno_docker_list_containers.sh`
 
 ...if you see a container listed with `!---not_managed_by_compose---!` you'll need to make sure you know how to recreate this container after the upgrade.
 

--- a/syno_docker_list_containers.sh
+++ b/syno_docker_list_containers.sh
@@ -26,7 +26,10 @@ done
 
 # Print the header
 printf "%-${max_container_length}s  %s\n" "Container" "Compose_Location"
-printf "%-${max_container_length}s  %s\n" "$(printf '%*s' "${max_container_length}" | tr ' ' '-')" "$(printf '%*s' "${max_location_length}" | tr ' ' '-')"
+printf "%-${max_container_length}s  %-${max_location_length}s\n" \
+  "$(printf '%*s' "${max_container_length}" | tr ' ' '-')" \
+  "$(printf '%*s' "${max_location_length}" | tr ' ' '-')"
+
 
 # Print the sorted container information
 for info in "${sorted_containers_info[@]}"; do

--- a/syno_docker_list_containers.sh
+++ b/syno_docker_list_containers.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Store container information in an array
+containers_info=()
+
+# Get the list of containers and their compose locations
+for c in $(docker ps -q); do
+    container_info=$(docker inspect "$c" --format '{{.Name}} {{if index .Config.Labels "com.docker.compose.project.config_files"}}{{index .Config.Labels "com.docker.compose.project.config_files"}}{{else}}!---not_managed_by_compose---!{{end}}')
+    containers_info+=("$container_info")
+done
+
+# Sort the array based on the second field (compose location)
+IFS=$'\n' sorted_containers_info=($(printf "%s\n" "${containers_info[@]}" | sort -u -t " " -k 2))
+
+# Calculate the maximum length for the container names and compose locations
+max_container_length=0
+max_location_length=0
+for info in "${sorted_containers_info[@]}"; do
+    container=$(echo "$info" | awk '{print $1}')
+    location=$(echo "$info" | awk '{print $2}')
+    [ ${#container} -gt $max_container_length ] && max_container_length=${#container}
+    [ ${#location} -gt $max_location_length ] && max_location_length=${#location}
+done
+
+# Print the header
+printf "%-${max_container_length}s  %s\n" "Container" "Compose_Location"
+printf "%-${max_container_length}s  %s\n" "$(printf '%*s' "${max_container_length}" | tr ' ' '-')" "$(printf '%*s' "${max_location_length}" | tr ' ' '-')"
+
+# Print the sorted container information
+for info in "${sorted_containers_info[@]}"; do
+    container=$(echo "$info" | awk '{print $1}')
+    location=$(echo "$info" | sed -e 's/^[^ ]* //')
+    printf "%-${max_container_length}s  %s\n" "$container" "$location"
+done
+

--- a/syno_docker_list_containers.sh
+++ b/syno_docker_list_containers.sh
@@ -27,8 +27,8 @@ done
 # Print the header
 printf "%-${max_container_length}s  %s\n" "Container" "Compose_Location"
 printf "%-${max_container_length}s  %-${max_location_length}s\n" \
-  "$(printf '%*s' "${max_container_length}" | tr ' ' '-')" \
-  "$(printf '%*s' "${max_location_length}" | tr ' ' '-')"
+  "$(printf '%*s' "${max_container_length}" '' | tr ' ' '-')" \
+  "$(printf '%*s' "${max_location_length}" '' | tr ' ' '-')"
 
 
 # Print the sorted container information

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -942,7 +942,7 @@ execute_restore_script() {
 #======================================================================================================================
 execute_start_syno() {
     print_status "Starting Docker service - May take a while to restart ${RUNNING_CONTAINERS} containers... (up to ${SYNO_SERVICE_START_TIMEOUT})"
-}
+
     if [ "${stage}" = 'false' ] ; then
         case "${dsm_major_version}" in
             "6")

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -14,6 +14,19 @@
 #======================================================================================================================
 
 #======================================================================================================================
+# Displays error message on console and terminates with non-zero error.
+#======================================================================================================================
+# Arguments:
+#   $1 - Error message to display.
+# Outputs:
+#   Writes error message to stderr, non-zero exit code.
+#======================================================================================================================
+terminate() {
+    printf "${RED}${BOLD}%s${NC}\n" "ERROR: $1"
+    exit 1
+}
+
+#======================================================================================================================
 # Constants
 #======================================================================================================================
 readonly RED='\e[31m' # Red color
@@ -29,7 +42,11 @@ readonly GITHUB_API_COMPOSE='https://api.github.com/repos/docker/compose/release
 readonly SYNO_DOCKER_SERV_NAME6='pkgctl-Docker'
 readonly SYNO_DOCKER_SERV_NAME7='ContainerManager'
 readonly SYNO_SERVICE_TIMEOUT='5m'
-readonly SYNO_DOCKER_DIR='/var/packages/ContainerManager'
+[ -d "/var/packages/ContainerManager" ] && readonly SYNO_DOCKER_DIR='/var/packages/ContainerManager'
+[ -d "/var/packages/Docker" ] && readonly SYNO_DOCKER_DIR='/var/packages/Docker'
+if [ -z "$SYNO_DOCKER_DIR" ]; then
+    terminate "Docker (or ContainerManager) folder was not found."
+fi
 readonly SYNO_DOCKER_BIN_PATH="${SYNO_DOCKER_DIR}/target/usr"
 readonly SYNO_DOCKER_BIN="${SYNO_DOCKER_BIN_PATH}/bin"
 readonly SYNO_DOCKER_SCRIPT_PATH="${SYNO_DOCKER_DIR}/scripts"
@@ -105,19 +122,6 @@ usage() {
     echo "  update                 Update Docker and Docker Compose to target version (creates backup first)"
     echo "  validate               Validates versions available for update"
     echo
-}
-
-#======================================================================================================================
-# Displays error message on console and terminates with non-zero error.
-#======================================================================================================================
-# Arguments:
-#   $1 - Error message to display.
-# Outputs:
-#   Writes error message to stderr, non-zero exit code.
-#======================================================================================================================
-terminate() {
-    printf "${RED}${BOLD}%s${NC}\n" "ERROR: $1"
-    exit 1
 }
 
 #======================================================================================================================

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -43,7 +43,7 @@ readonly SYNO_SERVICE_TIMEOUT='5m'
 [ -d "/var/packages/ContainerManager" ] && readonly SYNO_DOCKER_DIR='/var/packages/ContainerManager' && \
 	readonly SYNO_DOCKER_SERV_NAME='ContainerManager'
 [ -d "/var/packages/Docker" ] && readonly SYNO_DOCKER_DIR='/var/packages/Docker' && \
-	readonly SYNO_DOCKER_SERV_NAME='Docker'
+	readonly SYNO_DOCKER_SERV_NAME='pkgctl-Docker'
 if [ -z "$SYNO_DOCKER_DIR" ]; then
     terminate "Docker (or ContainerManager) folder was not found."
 fi

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -27,9 +27,9 @@ readonly DOWNLOAD_DOCKER="https://download.docker.com/linux/static/stable/${CPU_
 readonly DOWNLOAD_GITHUB='https://github.com/docker/compose'
 readonly GITHUB_API_COMPOSE='https://api.github.com/repos/docker/compose/releases/latest'
 readonly SYNO_DOCKER_SERV_NAME6='pkgctl-Docker'
-readonly SYNO_DOCKER_SERV_NAME7='Docker'
+readonly SYNO_DOCKER_SERV_NAME7='ContainerManager'
 readonly SYNO_SERVICE_TIMEOUT='5m'
-readonly SYNO_DOCKER_DIR='/var/packages/Docker'
+readonly SYNO_DOCKER_DIR='/var/packages/ContainerManager'
 readonly SYNO_DOCKER_BIN_PATH="${SYNO_DOCKER_DIR}/target/usr"
 readonly SYNO_DOCKER_BIN="${SYNO_DOCKER_BIN_PATH}/bin"
 readonly SYNO_DOCKER_SCRIPT_PATH="${SYNO_DOCKER_DIR}/scripts"
@@ -38,7 +38,11 @@ readonly SYNO_DOCKER_JSON_PATH="${SYNO_DOCKER_DIR}/etc"
 readonly SYNO_DOCKER_JSON="${SYNO_DOCKER_JSON_PATH}/dockerd.json"
 readonly SYNO_DOCKER_JSON_CONFIG="{
     \"data-root\" : \"$SYNO_DOCKER_DIR/target/docker\",
-    \"log-driver\" : \"json-file\",
+    \"log-driver\" : \"local\",
+    \"log-opts\" : {
+		\"max-size\" : \"10m\",
+		\"max-file\" : \"3\"
+	},
     \"registry-mirrors\" : [],
     \"group\": \"administrators\"
 }"

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -39,11 +39,11 @@ readonly CPU_ARCH='x86_64'
 readonly DOWNLOAD_DOCKER="https://download.docker.com/linux/static/stable/${CPU_ARCH}"
 readonly DOWNLOAD_GITHUB='https://github.com/docker/compose'
 readonly GITHUB_API_COMPOSE='https://api.github.com/repos/docker/compose/releases/latest'
-readonly SYNO_DOCKER_SERV_NAME6='pkgctl-Docker'
-readonly SYNO_DOCKER_SERV_NAME7='ContainerManager'
 readonly SYNO_SERVICE_TIMEOUT='5m'
-[ -d "/var/packages/ContainerManager" ] && readonly SYNO_DOCKER_DIR='/var/packages/ContainerManager'
-[ -d "/var/packages/Docker" ] && readonly SYNO_DOCKER_DIR='/var/packages/Docker'
+[ -d "/var/packages/ContainerManager" ] && readonly SYNO_DOCKER_DIR='/var/packages/ContainerManager' && \
+	readonly SYNO_DOCKER_SERV_NAME='ContainerManager'
+[ -d "/var/packages/Docker" ] && readonly SYNO_DOCKER_DIR='/var/packages/Docker' && \
+	readonly SYNO_DOCKER_SERV_NAME='Docker'
 if [ -z "$SYNO_DOCKER_DIR" ]; then
     terminate "Docker (or ContainerManager) folder was not found."
 fi
@@ -621,20 +621,20 @@ execute_stop_syno() {
     if [ "${stage}" = 'false' ] ; then
         case "${dsm_major_version}" in
             "6")
-                syno_status=$(synoservicectl --status "${SYNO_DOCKER_SERV_NAME6}" | grep running -o)
+                syno_status=$(synoservicectl --status "${SYNO_DOCKER_SERV_NAME}" | grep running -o)
                 if [ "${syno_status}" = 'running' ] ; then
-                    timeout --foreground "${SYNO_SERVICE_TIMEOUT}" synoservicectl --stop "${SYNO_DOCKER_SERV_NAME6}"
-                    syno_status=$(synoservicectl --status "${SYNO_DOCKER_SERV_NAME6}" | grep stop -o)
+                    timeout --foreground "${SYNO_SERVICE_TIMEOUT}" synoservicectl --stop "${SYNO_DOCKER_SERV_NAME}"
+                    syno_status=$(synoservicectl --status "${SYNO_DOCKER_SERV_NAME}" | grep stop -o)
                     if [ "${syno_status}" != 'stop' ] ; then
                         terminate "Could not stop Docker daemon"
                     fi
                 fi
                 ;;
             "7")
-                syno_status=$(synopkg status "${SYNO_DOCKER_SERV_NAME7}" | grep started -o)
+                syno_status=$(synopkg status "${SYNO_DOCKER_SERV_NAME}" | grep started -o)
                 if [ "${syno_status}" = 'started' ] ; then
-                    timeout --foreground "${SYNO_SERVICE_TIMEOUT}" synopkg stop "${SYNO_DOCKER_SERV_NAME7}"
-                    syno_status=$(synopkg status "${SYNO_DOCKER_SERV_NAME7}" | grep stopped -o)
+                    timeout --foreground "${SYNO_SERVICE_TIMEOUT}" synopkg stop "${SYNO_DOCKER_SERV_NAME}"
+                    syno_status=$(synopkg status "${SYNO_DOCKER_SERV_NAME}" | grep stopped -o)
                     if [ "${syno_status}" != 'stopped' ] ; then
                         terminate "Could not stop Docker daemon"
                     fi
@@ -940,9 +940,9 @@ execute_start_syno() {
     if [ "${stage}" = 'false' ] ; then
         case "${dsm_major_version}" in
             "6")
-                timeout --foreground "${SYNO_SERVICE_TIMEOUT}" synoservicectl --start "${SYNO_DOCKER_SERV_NAME6}"
+                timeout --foreground "${SYNO_SERVICE_TIMEOUT}" synoservicectl --start "${SYNO_DOCKER_SERV_NAME}"
 
-                syno_status=$(synoservicectl --status "${SYNO_DOCKER_SERV_NAME6}" | grep running -o)
+                syno_status=$(synoservicectl --status "${SYNO_DOCKER_SERV_NAME}" | grep running -o)
                 if [ "${syno_status}" != 'running' ] ; then
                     if [ "${force}" != 'true' ] ; then
                         terminate "Could not bring Docker Engine back online"
@@ -952,9 +952,9 @@ execute_start_syno() {
                 fi
                 ;;
             "7")
-                timeout --foreground "${SYNO_SERVICE_TIMEOUT}" synopkg start "${SYNO_DOCKER_SERV_NAME7}"
+                timeout --foreground "${SYNO_SERVICE_TIMEOUT}" synopkg start "${SYNO_DOCKER_SERV_NAME}"
 
-                syno_status=$(synopkg status "${SYNO_DOCKER_SERV_NAME7}" | grep started -o)
+                syno_status=$(synopkg status "${SYNO_DOCKER_SERV_NAME}" | grep started -o)
                 if [ "${syno_status}" != 'started' ] ; then
                     if [ "${force}" != 'true' ] ; then
                         terminate "Could not bring Docker Engine back online"


### PR DESCRIPTION
This modification fixes the name of the package and the packages directory from `Docker` to `ContainerManager` for DSM 7.2

It also changes the default logger to the [local file logging driver](https://docs.docker.com/config/containers/logging/local/) which is a more efficient driver than the [JSON File logging driver](https://docs.docker.com/config/containers/logging/json-file/) and also does file rotations by default, avoiding the potential issue of running out of file space on your host due to much larger and non-rotated log files accumulating.

I have not run into issues with this so far; I am able to start and stop containers from the Container Manager UI, all of my containers were able to run fine on custom network or default bridge with no issues. The only issue is the absense of any logs in the Container Manager UI. `docker log` works just fine, as do log-exposure apps like `dozzle`.

From the Docker documentation:

> Docker keeps the json-file logging driver (without log-rotation) as a default to remain backward compatibility with older versions of Docker, and for situations where Docker is used as runtime for Kubernetes.
>
>For other situations, the local logging driver is recommended as it performs log-rotation by default, and uses a more efficient file format